### PR TITLE
chore: Add CODEOWNERS and automatic issue labels

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @looker-open-source/looker-embed-demo-team

--- a/.github/workflows/p3-issue-label.yml
+++ b/.github/workflows/p3-issue-label.yml
@@ -1,0 +1,21 @@
+name: Label all new/reopened issues with P3
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues_p3:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["p3"]
+            })

--- a/.github/workflows/triage-issue-label.yml
+++ b/.github/workflows/triage-issue-label.yml
@@ -1,0 +1,20 @@
+name: Label issues that need triage
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  label_issues_p3:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["need triage"]
+            })


### PR DESCRIPTION
This will add a proper CODEOWNERS file and automatically set new issues to 'p3' and 'needs triage'.