### PR TITLE
feature: cloud function security improvement with shared secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ terraform.tfstate*
 *.tfstate
 .venv
 node_modules
-dist/
+
+.vertex_cf_auth_token
+dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.1
+
+### Added
+- Shared secret for the cloud function and explore assistant extension
+- Terraform code for managing the token in the GCP Secrets Manager
+
 ## v2.0
 
 There are many breaking changes in this version.

--- a/explore-assistant-backend/README.md
+++ b/explore-assistant-backend/README.md
@@ -24,12 +24,20 @@ terraform init
 
 ### Cloud Function Backend
 
+First create a file that will contain the LOOKER_AUTH_TOKEN and place it at the root. This will be used my the cloud function locally, as well as the extension framework app.
+
+```bash
+openssl rand -base64 32 > .vertex_cf_auth_token
+
+```
+
 To deploy the Cloud Function backend:
 
 ```bash
 export TF_VAR_project_id=XXX
 export TF_VAR_use_bigquery_backend=0
 export TF_VAR_use_cloud_function_backend=1
+export TF_VAR_looker_auth_token=$(cat ../../.vertex_cf_auth_token)
 terraform plan
 terraform apply
 ```

--- a/explore-assistant-backend/README.md
+++ b/explore-assistant-backend/README.md
@@ -24,7 +24,7 @@ terraform init
 
 ### Cloud Function Backend
 
-First create a file that will contain the LOOKER_AUTH_TOKEN and place it at the root. This will be used my the cloud function locally, as well as the extension framework app.
+First create a file that will contain the LOOKER_AUTH_TOKEN and place it at the root. This will be used my the cloud function locally, as well as the extension framework app. The value of this token will uplaoded to the GCP project as secret to be used by the Cloud Function.
 
 ```bash
 openssl rand -base64 32 > .vertex_cf_auth_token
@@ -38,6 +38,7 @@ export TF_VAR_project_id=XXX
 export TF_VAR_use_bigquery_backend=0
 export TF_VAR_use_cloud_function_backend=1
 export TF_VAR_looker_auth_token=$(cat ../../.vertex_cf_auth_token)
+terraform init
 terraform plan
 terraform apply
 ```

--- a/explore-assistant-backend/README.md
+++ b/explore-assistant-backend/README.md
@@ -24,7 +24,7 @@ terraform init
 
 ### Cloud Function Backend
 
-First create a file that will contain the LOOKER_AUTH_TOKEN and place it at the root. This will be used my the cloud function locally, as well as the extension framework app. The value of this token will uplaoded to the GCP project as secret to be used by the Cloud Function.
+First create a file that will contain the LOOKER_AUTH_TOKEN and place it at the root. This will be used my the cloud function locally, as well as the extension framework app. The value of this token will uploaded to the GCP project as secret to be used by the Cloud Function.
 
 ```bash
 openssl rand -base64 32 > .vertex_cf_auth_token

--- a/explore-assistant-backend/terraform/main.tf
+++ b/explore-assistant-backend/terraform/main.tf
@@ -21,7 +21,8 @@ module "project-services" {
     "storage-api.googleapis.com",
     "storage.googleapis.com",
     "aiplatform.googleapis.com",
-    "compute.googleapis.com"
+    "compute.googleapis.com",
+    "secretmanager.googleapis.com",
   ]
 }
 

--- a/explore-assistant-cloud-function/README.md
+++ b/explore-assistant-cloud-function/README.md
@@ -43,7 +43,7 @@ To set up and run the function locally, follow these steps:
 3. Run the function locally by executing the main script:
 
     ```bash
-    PROJECT=XXX REGION=us-central1 python main.py
+    PROJECT=XXXX LOCATION=us-central-1 VERTEX_CF_AUTH_TOKEN=$(cat ../.vertex_cf_auth_token) python main.py
     ```
 
 4. Test calling the endpoint locally with a custom query and parameter declaration

--- a/explore-assistant-cloud-function/README.md
+++ b/explore-assistant-cloud-function/README.md
@@ -49,7 +49,7 @@ To set up and run the function locally, follow these steps:
 4. Test calling the endpoint locally with a custom query and parameter declaration
    
    ```bash
-     curl -X POST -H "Content-Type: application/json" -d '{"contents":"how are you doing?", "parameters":{"max_output_tokens": 1000}}' http://localhost:8000
+     python test.py
    ```
 
 This setup allows developers to test and modify the function in a local environment before deploying it to a cloud function service.

--- a/explore-assistant-cloud-function/README.md
+++ b/explore-assistant-cloud-function/README.md
@@ -22,6 +22,8 @@ The cloud function integrates with Vertex AI and utilizes the `GenerativeModel` 
 
 8. **Execution Environment**: When executed, the script checks if it's running in a Google Cloud Function environment and acts accordingly; otherwise, it starts a Flask web server for local development or testing.
 
+9. **Endpoint securizaty**: We are using a simple shared secret approach to securing the endpoint. The request body is checked against the supplied signature in the X-Signature header. We aren't yet guarding against replay attacks with nonces.
+
 ## Local Development
 
 To set up and run the function locally, follow these steps:

--- a/explore-assistant-cloud-function/README.md
+++ b/explore-assistant-cloud-function/README.md
@@ -22,7 +22,7 @@ The cloud function integrates with Vertex AI and utilizes the `GenerativeModel` 
 
 8. **Execution Environment**: When executed, the script checks if it's running in a Google Cloud Function environment and acts accordingly; otherwise, it starts a Flask web server for local development or testing.
 
-9. **Endpoint securizaty**: We are using a simple shared secret approach to securing the endpoint. The request body is checked against the supplied signature in the X-Signature header. We aren't yet guarding against replay attacks with nonces.
+9. **Endpoint Security**: We are using a simple shared secret approach to securing the endpoint. The request body is checked against the supplied signature in the X-Signature header. We aren't yet guarding against replay attacks with nonces.
 
 ## Local Development
 

--- a/explore-assistant-cloud-function/main.py
+++ b/explore-assistant-cloud-function/main.py
@@ -116,6 +116,7 @@ def create_flask_app():
             return handle_options_request(request)
 
         incoming_request = request.get_json()
+        print(incoming_request)
         contents = incoming_request.get("contents")
         parameters = incoming_request.get("parameters")
         if contents is None:

--- a/explore-assistant-cloud-function/test.py
+++ b/explore-assistant-cloud-function/test.py
@@ -1,0 +1,43 @@
+import hmac
+import hashlib
+import requests
+import json
+
+def generate_hmac_signature(secret_key, data):
+    """
+    Generate HMAC-SHA256 signature for the given data using the secret key.
+    """
+    hmac_obj = hmac.new(secret_key.encode(), json.dumps(data).encode(), hashlib.sha256)
+    return hmac_obj.hexdigest()
+
+def send_request(url, data, signature):
+    """
+    Send a POST request to the given URL with the provided data and HMAC signature.
+    """
+    headers = {
+        'Content-Type': 'application/json',
+        'X-Signature': signature
+    }
+    response = requests.post(url, headers=headers, json=data)
+    return response.text
+
+def main():
+    # URL of the endpoint
+    url = 'http://localhost:8000'
+
+    # Request payload
+    data = {"contents":"how are you doing?", "parameters":{"max_output_tokens": 1000}}
+
+    # Read the secret key from a file
+    with open('../.vertex_cf_auth_token', 'r') as file:
+        secret_key = file.read().strip()  # Remove any potential newline characters
+
+    # Generate HMAC signature
+    signature = generate_hmac_signature(secret_key, data)
+
+    # Send the request
+    response = send_request(url, data, signature)
+    print("Response from server:", response)
+
+if __name__ == "__main__":
+    main()

--- a/explore-assistant-extension/.env_example
+++ b/explore-assistant-extension/.env_example
@@ -1,6 +1,8 @@
-VERTEX_AI_ENDPOINT=<This is your Deployed Cloud Function Endpoint>
 LOOKER_MODEL=<This is your Looker model name>
 LOOKER_EXPLORE=<This is your Looker explore name>
+
+VERTEX_AI_ENDPOINT=<This is your Deployed Cloud Function Endpoint>
+VERTEX_CF_AUTH_TOKEN=<This is the token used to communicate with the cloud function>
 
 VERTEX_BIGQUERY_LOOKER_CONNECTION_NAME=<This is the connection name that has vertex ai external connector>
 VERTEX_BIGQUERY_MODEL_ID=<This is the model id that you want to use for prediction>

--- a/explore-assistant-extension/README.md
+++ b/explore-assistant-extension/README.md
@@ -78,10 +78,11 @@ jsonPayload.component="explore-assistant-metadata"
    VERTEX_BIGQUERY_LOOKER_CONNECTION_NAME=<This is the connection name where we can find the Explore URL examples>
    ```
 
-   If you're using the Cloud Function backend, replace the default:
+   If you're using the Cloud Function backend, replace the defaults:
 
    ```
    VERTEX_AI_ENDPOINT=<This is your Deployed Cloud Function Endpoint>
+   VERTEX_CF_AUTH_TOKEN=<This is the token used to communicate with the cloud function>
    ```
 
    If you're using the BigQuery Backend replace the default:

--- a/explore-assistant-extension/package-lock.json
+++ b/explore-assistant-extension/package-lock.json
@@ -16,6 +16,8 @@
         "@looker/extension-sdk-react": "^24.2.0",
         "@looker/sdk": "^24.2.0",
         "@reduxjs/toolkit": "^2.2.2",
+        "@types/crypto-js": "^4.2.2",
+        "crypto-js": "^4.2.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-is": "^16.13.1",
@@ -2775,6 +2777,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ=="
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
@@ -4347,6 +4354,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/css-color-keywords": {
       "version": "1.0.0",

--- a/explore-assistant-extension/package.json
+++ b/explore-assistant-extension/package.json
@@ -24,6 +24,8 @@
     "@looker/extension-sdk-react": "^24.2.0",
     "@looker/sdk": "^24.2.0",
     "@reduxjs/toolkit": "^2.2.2",
+    "@types/crypto-js": "^4.2.2",
+    "crypto-js": "^4.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-is": "^16.13.1",

--- a/explore-assistant-extension/src/App.tsx
+++ b/explore-assistant-extension/src/App.tsx
@@ -12,19 +12,19 @@ import ExploreAssistantPage from './pages/ExploreAssistantPage'
 
 const ExploreApp = () => {
   return (
-    <Router>
-      <Switch>
-        <Route path="/" exact>
-          <LandingPage />
-        </Route>
-        <Route path="/assistant">
-          <ExploreAssistantPage />
-        </Route>
-        <Route>
-          <Redirect to="/" />
-        </Route>
-      </Switch>
-    </Router>
+      <Router>
+        <Switch>
+          <Route path="/" exact>
+            <LandingPage />
+          </Route>
+          <Route path="/assistant">
+            <ExploreAssistantPage />
+          </Route>
+          <Route>
+            <Redirect to="/" />
+          </Route>
+        </Switch>
+      </Router>
   )
 }
 


### PR DESCRIPTION
We don't want an open endpoint for the gemini model. We are securing the endpoint by using a shared secret in the cloud function and the extension framework app. The secret is used to sign the request body on the extension framework side, and is verified on the cloud function side.

## Added
- Shared secret for the cloud function and explore assistant extension
- Terraform code for managing the token in the GCP Secrets Manager
