### PR TITLE
Feat: Model name is configurable for the cloud function

### DIFF
--- a/explore-assistant-cloud-function/README.md
+++ b/explore-assistant-cloud-function/README.md
@@ -55,3 +55,15 @@ To set up and run the function locally, follow these steps:
    ```
 
 This setup allows developers to test and modify the function in a local environment before deploying it to a cloud function service.
+
+## Model configuration
+
+By default, the cloud function will use a default model. However, you may want to test out different Gemini models are they are released. We have made the model name configurable via an environment variable. 
+
+In development, you can run the main script with a new MODEL_NAME variable:
+
+```bash
+PROJECT=XXXX LOCATION=us-central-1 VERTEX_CF_AUTH_TOKEN=$(cat ../.vertex_cf_auth_token) MODEL_NAME=XXXXX python main.py
+```
+
+In production, on the cloud function, you can manually set a variable in the GCP UI. Updating the variable will re-deploy the cloud function.

--- a/explore-assistant-cloud-function/main.py
+++ b/explore-assistant-cloud-function/main.py
@@ -37,6 +37,8 @@ logging.basicConfig(level=logging.INFO)
 project = os.environ.get("PROJECT")
 location = os.environ.get("REGION")
 vertex_cf_auth_token = os.environ.get("VERTEX_CF_AUTH_TOKEN")
+model_name = os.environ.get("MODEL_NAME", "gemini-1.0-pro-001")
+
 vertexai.init(project=project, location=location)
 
 def get_response_headers(request):
@@ -61,7 +63,7 @@ def has_valid_signature(request):
 
     return hmac.compare_digest(signature, expected_signature)
 
-def generate_looker_query(contents, parameters=None, model_name="gemini-1.0-pro-001"):
+def generate_looker_query(contents, parameters=None):
 
    # Define default parameters
     default_parameters = {


### PR DESCRIPTION

By default, the cloud function will use a default model. However, you may want to test out different Gemini models are they are released. We have made the model name configurable via an environment variable. 

In development, you can run the main script with a new MODEL_NAME variable:

```bash
PROJECT=XXXX LOCATION=us-central-1 VERTEX_CF_AUTH_TOKEN=$(cat ../.vertex_cf_auth_token) MODEL_NAME=XXXXX python main.py
```

In production, on the cloud function, you can manually set a variable in the GCP UI. Updating the variable will re-deploy the cloud function.

<img width="416" alt="Screenshot 2024-05-23 at 12 23 58 PM" src="https://github.com/looker-open-source/looker-explore-assistant/assets/2035993/bacc66fb-c2bd-45fe-bc68-2cead9e5b7e1">

