### PR TITLE
Update the cloud function to use gemini flash

### DIFF
--- a/explore-assistant-cloud-function/main.py
+++ b/explore-assistant-cloud-function/main.py
@@ -61,7 +61,7 @@ def has_valid_signature(request):
 
     return hmac.compare_digest(signature, expected_signature)
 
-def generate_looker_query(contents, parameters=None, model_name="gemini-1.0-pro-001"):
+def generate_looker_query(contents, parameters=None, model_name="gemini-1.5-flash"):
 
    # Define default parameters
     default_parameters = {


### PR DESCRIPTION
Gemini Flash 1.5 is now in GA. We are updating the Cloud Function to use it by default. The BigQuery model connector still only supports gemini-pro-1.0 as of this PR. 

<img width="817" alt="Screenshot 2024-05-31 at 10 32 25 AM" src="https://github.com/looker-open-source/looker-explore-assistant/assets/2035993/4d002149-297f-40c5-b6bf-e7042dabe20d">
