### PR TITLE
feat: add failsafe for missing bigquery connection

### DIFF
--- a/explore-assistant-examples/README.md
+++ b/explore-assistant-examples/README.md
@@ -45,7 +45,7 @@ python load_examples.py --project_id YOUR_PROJECT_ID --explore_id YOUR_EXPLORE_I
 
 Load the refinement examples
 ```bash
- python load_examples.py --project_id YOUR_PROJECT_ID --explore_id YOUR_EXPLORE_ID --table_id explore_assistant_refinement_examples --json_file refinement_examples.json 
+ python load_examples.py --project_id YOUR_PROJECT_ID --explore_id YOUR_EXPLORE_ID --table_id explore_assistant_refinement_examples --json_file refinement_examples.json
  ```
 ### Description
 
@@ -68,3 +68,7 @@ This Python script is designed to manage data uploads from a JSON file into a Go
 
 6. **Error Handling**:
    - Throughout the data deletion and insertion processes, the script checks for and reports any errors that occur. This is vital for debugging and ensuring data integrity.
+
+### Add examples directly to the extension bundle
+
+If examples need to be added directly to the extension bundle, leave out the connection parameter blank in the `.env` file. This will be check at build time and both example files in this directory will be added to the extension bundle.

--- a/explore-assistant-extension/.env_example
+++ b/explore-assistant-extension/.env_example
@@ -1,10 +1,10 @@
-LOOKER_MODEL=<This is your Looker model name>
-LOOKER_EXPLORE=<This is your Looker explore name>
-
-VERTEX_AI_ENDPOINT=<This is your Deployed Cloud Function Endpoint>
-VERTEX_CF_AUTH_TOKEN=<This is the token used to communicate with the cloud function>
-
-VERTEX_BIGQUERY_LOOKER_CONNECTION_NAME=<This is the connection name that has vertex ai external connector>
-VERTEX_BIGQUERY_MODEL_ID=<This is the model id that you want to use for prediction>
-BIGQUERY_EXAMPLE_PROMPTS_CONNECTION_NAME=<The BQ connection name in Looker that has query access to example prompts. This may be the same as the Vertex Connection Name if using just one gcp project>
-BIGQUERY_EXAMPLE_PROMPTS_DATASET_NAME=<This is the dataset and project that contain the Example prompt data, assuming that differs from the Looker connection>
+#LOOKER_MODEL=<This is your Looker model name>
+#LOOKER_EXPLORE=<This is your Looker explore name>
+#
+#VERTEX_AI_ENDPOINT=<This is your Deployed Cloud Function Endpoint>
+#VERTEX_CF_AUTH_TOKEN=<This is the token used to communicate with the cloud function>
+#
+#VERTEX_BIGQUERY_LOOKER_CONNECTION_NAME=<This is the connection name that has vertex ai external connector>
+#VERTEX_BIGQUERY_MODEL_ID=<This is the model id that you want to use for prediction>
+#BIGQUERY_EXAMPLE_PROMPTS_CONNECTION_NAME=<The BQ connection name in Looker that has query access to example prompts. This may be the same as the Vertex Connection Name if using just one gcp project>
+#BIGQUERY_EXAMPLE_PROMPTS_DATASET_NAME=<This is the dataset and project that contain the Example prompt data, assuming that differs from the Looker connection>

--- a/explore-assistant-extension/src/hooks/useBigQueryExamples.ts
+++ b/explore-assistant-extension/src/hooks/useBigQueryExamples.ts
@@ -38,31 +38,43 @@ export const useBigQueryExamples = () => {
   }
 
   const getExamplePrompts = async () => {
-    const sql = `
+    if (!process.env.BIGQUERY_EXAMPLE_PROMPTS_CONNECTION_NAME) {
+      const generationExamples = require('../../../explore-assistant-examples/examples.json')
+      return dispatch(setExploreGenerationExamples(generationExamples))
+    }
+    else {
+      const sql = `
       SELECT
           examples
       FROM
         \`${datasetName}.explore_assistant_examples\`
         WHERE explore_id = '${LOOKER_MODEL}:${LOOKER_EXPLORE}'
     `
-    return runExampleQuery(sql).then((response) => {
-      const generationExamples = JSON.parse(response[0]['examples'])
-      dispatch(setExploreGenerationExamples(generationExamples))
-    })
+      return runExampleQuery(sql).then((response) => {
+        const generationExamples = JSON.parse(response[0]['examples'])
+        dispatch(setExploreGenerationExamples(generationExamples))
+      })
+    }
   }
 
   const getRefinementPrompts = async () => {
-    const sql = `
+    if (!process.env.BIGQUERY_EXAMPLE_PROMPTS_CONNECTION_NAME) {
+      const refinementExamples = require('../../../explore-assistant-examples/refinement_examples.json')
+      return dispatch(setExploreRefinementExamples(refinementExamples))
+    }
+    else {
+      const sql = `
     SELECT
         examples
     FROM
       \`${datasetName}.explore_assistant_refinement_examples\`
       WHERE explore_id = '${LOOKER_MODEL}:${LOOKER_EXPLORE}'
   `
-    return runExampleQuery(sql).then((response) => {
-      const refinementExamples = JSON.parse(response[0]['examples'])
-      dispatch(setExploreRefinementExamples(refinementExamples))
-    })
+      return runExampleQuery(sql).then((response) => {
+        const refinementExamples = JSON.parse(response[0]['examples'])
+        dispatch(setExploreRefinementExamples(refinementExamples))
+      })
+    }
   }
 
   // get the example prompts
@@ -71,3 +83,4 @@ export const useBigQueryExamples = () => {
     getRefinementPrompts()
   }, [])
 }
+


### PR DESCRIPTION
In case a Bigquery connection is not configured or the user wants to include their primer examples to the bundle we can add a failsafe on `useBigQueryExamples.ts` to check for a connection variable in the environment and decide whether fetching the examples or using the ones in the 2nd-level folder `explore-assistant-examples`.

This works because `.env` is being loaded already by Webpack and we can do conditional compilation since the environment variables are available at build time.

I had to comment out the `.env_example` file as a tradeof but this ensures examples are only included in the bundle if a BigQuery connection is not set. Plus this is probably the least intrusive solution.