### PR TITLE
Fix: Don't re-run bigquery example creation

### DIFF
--- a/explore-assistant-backend/terraform/bigquery/main.tf
+++ b/explore-assistant-backend/terraform/bigquery/main.tf
@@ -30,7 +30,7 @@ resource "google_bigquery_job" "create_bq_model_llm" {
     query              = <<EOF
 CREATE OR REPLACE MODEL `${var.dataset_id}.explore_assistant_llm` 
 REMOTE WITH CONNECTION `${google_bigquery_connection.connection.name}` 
-OPTIONS (endpoint = 'gemini-pro')
+OPTIONS (endpoint = 'gemini-1.5-flash')
 EOF  
     create_disposition = ""
     write_disposition  = ""

--- a/explore-assistant-backend/terraform/bigquery_examples.tf
+++ b/explore-assistant-backend/terraform/bigquery_examples.tf
@@ -64,6 +64,10 @@ resource "google_bigquery_job" "create_explore_assistant_examples_table" {
 
   location = var.deployment_region
   depends_on = [ time_sleep.wait_after_apis_activate]
+
+  lifecycle {
+    ignore_changes  = [query, job_id]
+  }
 }
 
 
@@ -87,4 +91,7 @@ resource "google_bigquery_job" "create_explore_assistant_refinement_examples_tab
 
   location = var.deployment_region
   depends_on = [ time_sleep.wait_after_apis_activate]
+  lifecycle {
+    ignore_changes  = [query, job_id]
+  }
 }


### PR DESCRIPTION
If you re-run the `terraform apply` after you have uploaded examples to the table in BigQuery, the jobs will blow those away. Super frustrating! 

This change makes it that the jobs are only ever run once. 