### PR TITLE
fix(extension): remove fields marked as hidden from measures and dimensions

### DIFF
--- a/explore-assistant-extension/src/hooks/useLookerFields.ts
+++ b/explore-assistant-extension/src/hooks/useLookerFields.ts
@@ -24,27 +24,26 @@ export const useLookerFields = () => {
         if (!fields || !fields.dimensions || !fields.measures) {
           return
         }
-        const dimensions = fields.dimensions.map(
-          ({ name, type, description, tags }: any) => ({
+        const dimensions = fields.dimensions
+          .filter(({ hidden }: any) => !hidden)
+          .map(({ name, type, description, tags }: any) => ({
             name,
             type,
             description,
             tags,
-          }),
-        )
+          }))
 
-        const measures = fields.measures.map(
-          ({ name, type, description, tags }: any) => ({
+        const measures = fields.measures
+          .filter(({ hidden }: any) => !hidden)
+          .map(({ name, type, description, tags }: any) => ({
             name,
             type,
             description,
             tags,
-          }),
-        )
+          }))
 
         dispatch(setDimensions(dimensions))
         dispatch(setMeasures(measures))
       })
   }, [dispatch, lookerModel, lookerExplore]) // Dependencies array to avoid unnecessary re-executions
 }
-


### PR DESCRIPTION
Updating  extension useLookerFields hook functionality to exclude hidden fields. 
The changes ensure that fields marked as hidden in LookML are not available for LLM context generation.

Fixes #47
