### PR TITLE
Feature - history saves the entire contents of the thread

### DIFF
--- a/explore-assistant-examples/samples.json
+++ b/explore-assistant-examples/samples.json
@@ -1,17 +1,14 @@
 [
     {
       "category": "Cohorting",
-      "prompt": "Count of Users by first purchase date",
-      "color": "green"
+      "prompt": "Count of Users by first purchase date"
     },
     {
       "category": "Audience Building",
-      "prompt":"Users who have purchased more than 100 dollars worth of Calvin Klein products and have purchased in the last 30 days",
-      "color": "blue"
+      "prompt":"Users who have purchased more than 100 dollars worth of Calvin Klein products and have purchased in the last 30 days"
     },
     {
       "category": "Period Comparison",
-      "prompt": "Total revenue by category this year compared to last year in a line chart with year pivoted",
-      "color": "red"
+      "prompt": "Total revenue by category this year compared to last year in a line chart with year pivoted"
     }
 ]

--- a/explore-assistant-extension/.env_example
+++ b/explore-assistant-extension/.env_example
@@ -1,6 +1,3 @@
-LOOKER_MODEL=<This is your Looker model name>
-LOOKER_EXPLORE=<This is your Looker explore name>
-
 VERTEX_AI_ENDPOINT=<This is your Deployed Cloud Function Endpoint>
 VERTEX_CF_AUTH_TOKEN=<This is the token used to communicate with the cloud function>
 

--- a/explore-assistant-extension/README.md
+++ b/explore-assistant-extension/README.md
@@ -73,8 +73,6 @@ jsonPayload.component="explore-assistant-metadata"
    Regardless of the backend, you're going to need:
 
    ```
-   LOOKER_MODEL=<This is your Looker model name>
-   LOOKER_EXPLORE=<This is your Looker explore name>
    VERTEX_BIGQUERY_LOOKER_CONNECTION_NAME=<This is the connection name in Looker with the BQ project that has access to the remote connection and model>
    BIGQUERY_EXAMPLE_PROMPTS_CONNECTION_NAME=<The BQ connection name in Looker that has query access to example prompts. This may be the same as the Vertex Connection Name if using just one gcp project>
    BIGQUERY_EXAMPLE_PROMPTS_DATASET_NAME=<This is the dataset and project that contain the Example prompt data, assuming that differs from the Looker connection>

--- a/explore-assistant-extension/package-lock.json
+++ b/explore-assistant-extension/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
+        "@headlessui/react": "^1.7.19",
         "@looker/components": "^4.1.3",
         "@looker/components-providers": "1.5.31",
         "@looker/embed-sdk": "^1.6.1",
@@ -2327,6 +2328,23 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@headlessui/react": {
+      "version": "1.7.19",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.19.tgz",
+      "integrity": "sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/react-virtual": "^3.0.0-beta.60",
+        "client-only": "^0.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -3257,12 +3275,6 @@
         }
       }
     },
-    "node_modules/@reduxjs/toolkit/node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
-    },
     "node_modules/@reduxjs/toolkit/node_modules/redux-thunk": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
@@ -3461,6 +3473,33 @@
       "dependencies": {
         "@styled-system/core": "^5.1.2",
         "@styled-system/css": "^5.1.5"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.9.0.tgz",
+      "integrity": "sha512-5TeTSQBMV1PIFzBP9cduIX5klRaTvbOw+CxRx3LaUhwqiZLEZBZqz8anEIqG4eHNhDAe+BLarRDeNE9cNM1/EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.9.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.9.0.tgz",
+      "integrity": "sha512-Saga7/QRGej/IDCVP5BgJ1oDqlDT2d9rQyoflS3fgMS8ntJ8JGw/LBqK2GorHa06+VrNFc0tGz65XQHJQJetFQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@types/body-parser": {
@@ -3876,6 +3915,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
@@ -4985,6 +5025,12 @@
       "engines": {
         "node": ">=6.0"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
     },
     "node_modules/clone-deep": {
       "version": "4.0.1",
@@ -11458,14 +11504,10 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
     },
     "node_modules/redux-persist": {
       "version": "6.0.0",

--- a/explore-assistant-extension/package-lock.json
+++ b/explore-assistant-extension/package-lock.json
@@ -24,6 +24,7 @@
         "@reduxjs/toolkit": "^2.2.2",
         "@types/crypto-js": "^4.2.2",
         "@types/react": "^17.0.80",
+        "@types/uuid": "^10.0.0",
         "clsx": "^2.1.1",
         "crypto-js": "^4.2.0",
         "highlight.js": "^11.9.0",
@@ -42,7 +43,8 @@
         "sass": "^1.72.0",
         "sass-loader": "^14.1.1",
         "styled-components": "^5.3.11",
-        "tailwindcss": "^3.4.7"
+        "tailwindcss": "^3.4.7",
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.16.0",
@@ -3785,6 +3787,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
       "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -12968,13 +12976,14 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/explore-assistant-extension/package.json
+++ b/explore-assistant-extension/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
+    "@headlessui/react": "^1.7.19",
     "@looker/components": "^4.1.3",
     "@looker/components-providers": "1.5.31",
     "@looker/embed-sdk": "^1.6.1",

--- a/explore-assistant-extension/package.json
+++ b/explore-assistant-extension/package.json
@@ -32,6 +32,7 @@
     "@reduxjs/toolkit": "^2.2.2",
     "@types/crypto-js": "^4.2.2",
     "@types/react": "^17.0.80",
+    "@types/uuid": "^10.0.0",
     "clsx": "^2.1.1",
     "crypto-js": "^4.2.0",
     "highlight.js": "^11.9.0",
@@ -50,7 +51,8 @@
     "sass": "^1.72.0",
     "sass-loader": "^14.1.1",
     "styled-components": "^5.3.11",
-    "tailwindcss": "^3.4.7"
+    "tailwindcss": "^3.4.7",
+    "uuid": "^10.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.0",

--- a/explore-assistant-extension/src/App.tsx
+++ b/explore-assistant-extension/src/App.tsx
@@ -1,34 +1,12 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { hot } from 'react-hot-loader/root'
 import { Route, Switch, Redirect } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux'
-import {
-  setExploreId,
-  setExploreName,
-  setModelName,
-} from './slices/assistantSlice'
-import { RootState } from './store'
 import { useLookerFields } from './hooks/useLookerFields'
 import { useBigQueryExamples } from './hooks/useBigQueryExamples'
 import AgentPage from './pages/AgentPage'
 
 const ExploreApp = () => {
-  const dispatch = useDispatch()
-  const {
-    exploreName,
-    modelName,
-    exploreId,
-  } = useSelector((state: RootState) => state.assistant)
-  const LOOKER_EXPLORE_ID =
-    exploreId || `${process.env.LOOKER_MODEL}/${process.env.LOOKER_EXPLORE}` || ''
-  useEffect(() => {
-    dispatch(setExploreId(LOOKER_EXPLORE_ID))
-    dispatch(setModelName(modelName || process.env.LOOKER_MODEL || ''))
-    dispatch(setExploreName(exploreName || process.env.LOOKER_EXPLORE || ''))
-  }, [])
-
-
-  // load dimensions and measures into the state
+  // load dimensions, measures and examples into the state
   useLookerFields()
   useBigQueryExamples()
 

--- a/explore-assistant-extension/src/components/Chat/ExploreMessage.tsx
+++ b/explore-assistant-extension/src/components/Chat/ExploreMessage.tsx
@@ -3,8 +3,7 @@ import React from 'react'
 import Message from './Message'
 import { useContext } from 'react'
 import { ExtensionContext } from '@looker/extension-sdk-react'
-import { useDispatch, useSelector } from 'react-redux'
-import { RootState } from '../../store'
+import { useDispatch } from 'react-redux'
 import {
   openSidePanel,
   setSidePanelExploreUrl,
@@ -12,15 +11,16 @@ import {
 import { OpenInNew } from '@material-ui/icons'
 
 interface ExploreMessageProps {
+  exploreId: string
+  modelName: string
   prompt: string
   queryArgs: string
 }
 
-const ExploreMessage = ({ prompt, queryArgs }: ExploreMessageProps) => {
+const ExploreMessage = ({ modelName, exploreId, prompt, queryArgs }: ExploreMessageProps) => {
   const dispatch = useDispatch()
-  const { exploreId } = useSelector((state: RootState) => state.assistant)
   const { extensionSDK } = useContext(ExtensionContext)
-  const exploreHref = `/explore/${exploreId}?${queryArgs}`
+  const exploreHref = `/explore/${modelName}/${exploreId}?${queryArgs}`
   const openExplore = () => {
     extensionSDK.openBrowserWindow(exploreHref, '_blank')
   }

--- a/explore-assistant-extension/src/components/Chat/ExploreMessage.tsx
+++ b/explore-assistant-extension/src/components/Chat/ExploreMessage.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import Message from './Message'
-import { Link } from '@looker/components'
 import { useContext } from 'react'
 import { ExtensionContext } from '@looker/extension-sdk-react'
 import { useDispatch, useSelector } from 'react-redux'
@@ -10,7 +9,7 @@ import {
   openSidePanel,
   setSidePanelExploreUrl,
 } from '../../slices/assistantSlice'
-import { Explore, OpenInNew, Share } from '@material-ui/icons'
+import { OpenInNew } from '@material-ui/icons'
 
 interface ExploreMessageProps {
   prompt: string

--- a/explore-assistant-extension/src/components/Chat/SummaryMessage.tsx
+++ b/explore-assistant-extension/src/components/Chat/SummaryMessage.tsx
@@ -60,7 +60,7 @@ const SummaryMessage = ({ message }: SummaryMessageProps) => {
           <Spinner size={20} my={'u2'} />
         ) : (
           <>
-            <div className="">
+            <div className="text-sm mt-6">
               <MarkdownText text={summary} />
             </div>
           </>

--- a/explore-assistant-extension/src/components/Chat/SummaryMessage.tsx
+++ b/explore-assistant-extension/src/components/Chat/SummaryMessage.tsx
@@ -3,30 +3,55 @@ import React, { useEffect } from 'react'
 import Message from './Message'
 import useSendVertexMessage from '../../hooks/useSendVertexMessage'
 import MarkdownText from './MarkdownText'
+import { useDispatch } from 'react-redux'
+import {
+  SummarizeMesage,
+  updateLastHistoryEntry,
+  updateSummaryMessage,
+} from '../../slices/assistantSlice'
 
 interface SummaryMessageProps {
-  queryArgs: string
+  message: SummarizeMesage
 }
 
-const SummaryMessage = ({ queryArgs }: SummaryMessageProps) => {
+const SummaryMessage = ({ message }: SummaryMessageProps) => {
+  const queryArgs = message.exploreUrl
+
+  const dispatch = useDispatch()
   const [loading, setLoading] = React.useState<boolean>(true)
   const [summary, setSummary] = React.useState<string>('')
 
   const { summarizeExplore } = useSendVertexMessage()
 
   useEffect(() => {
+    if (message.summary) {
+      setSummary(message.summary)
+      setLoading(false)
+      return
+    }
+
     const fetchSummary = async () => {
       const response = await summarizeExplore(queryArgs)
       if (!response) {
         setSummary('There was an error summarizing the data')
       } else {
         setSummary(response)
+
+        // save to the store
+        dispatch(
+          updateSummaryMessage({ uuid: message.uuid, summary: response }),
+        )
+
+        // update the history with the current contents of the thread
+        dispatch(updateLastHistoryEntry())
       }
+
       setLoading(false)
     }
+
     fetchSummary()
-  }, [])
-  console.log(summary)
+  }, [message])
+
   return (
     <Message actor="system" createdAt={Date.now()}>
       <Section my={'u2'}>
@@ -37,7 +62,7 @@ const SummaryMessage = ({ queryArgs }: SummaryMessageProps) => {
           <>
             <div className="">
               <MarkdownText text={summary} />
-          </div>
+            </div>
           </>
         )}
       </Section>

--- a/explore-assistant-extension/src/components/ExploreEmbed.tsx
+++ b/explore-assistant-extension/src/components/ExploreEmbed.tsx
@@ -28,18 +28,21 @@ import React, { useContext, useRef, useEffect } from 'react'
 import styled from 'styled-components'
 import { LookerEmbedSDK } from '@looker/embed-sdk'
 import { ExtensionContext } from '@looker/extension-sdk-react'
-import { useSelector } from 'react-redux'
-import { RootState } from '../store'
 
 export interface ExploreEmbedProps {
-  exploreUrl: string
+  modelName: string | null | undefined
+  exploreId: string | null | undefined
+  exploreUrl: string | null | undefined
 }
 
-export const ExploreEmbed = ({ exploreUrl }: ExploreEmbedProps) => {
+export const ExploreEmbed = ({ modelName, exploreId, exploreUrl }: ExploreEmbedProps) => {
+
+  if(!modelName || !exploreId || !exploreUrl) {
+    return <></>
+  }
+
   const { extensionSDK } = useContext(ExtensionContext)
   const [exploreRunStart, setExploreRunStart] = React.useState(false)
-
-  const { exploreId } = useSelector((state: RootState) => state.assistant)
 
   const canceller = (event: any) => {
     return { cancel: !event.modal }
@@ -82,7 +85,7 @@ export const ExploreEmbed = ({ exploreUrl }: ExploreEmbedProps) => {
       })
       el.innerHTML = ''
       LookerEmbedSDK.init(hostUrl)
-      LookerEmbedSDK.createExploreWithId(exploreId)
+      LookerEmbedSDK.createExploreWithId(modelName + '/' + exploreId)
         .appendTo(el)
         .withClassName('looker-embed')
         .withParams(paramsObj)

--- a/explore-assistant-extension/src/components/SamplePrompts.tsx
+++ b/explore-assistant-extension/src/components/SamplePrompts.tsx
@@ -1,22 +1,22 @@
 import React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { resetChat, setIsChatMode, setQuery } from '../slices/assistantSlice'
+import {
+  AssistantState,
+  resetChat,
+  setIsChatMode,
+  setQuery,
+} from '../slices/assistantSlice'
 import { RootState } from '../store'
+
 
 const SamplePrompts = () => {
   const dispatch = useDispatch()
   const {
-    examples,
-    exploreId,
-  } = useSelector((state: RootState) => state.assistant)
-  const [samplesLoaded, setSamplesLoaded] = React.useState(false)
+    currentExplore: { modelName, exploreId },
+    examples: { exploreSamples },
+  } = useSelector((state: RootState) => state.assistant as AssistantState)
 
-  React.useEffect(() => {
-    if(examples.exploreSamples.length > 0) {
-      setSamplesLoaded(true)
-      console.log(examples.exploreSamples)
-    }
-  },[examples.exploreSamples])
+  const samples = exploreSamples[`${modelName}:${exploreId}`]
 
   const handleSubmit = (prompt: string) => {
     dispatch(resetChat())
@@ -24,35 +24,24 @@ const SamplePrompts = () => {
     dispatch(setIsChatMode(true))
   }
 
-  if(samplesLoaded) {
-    const categorizedPrompts = JSON.parse(
-      examples.exploreSamples.filter(
-        explore => explore.explore_id === exploreId.replace("/",":")
-      )
-      ?.[0]
-      ?.['samples'] ?? '[]'
-    )
+  if(!samples) return <></>
 
-    return (
-      <div className="flex flex-wrap max-w-5xl">
-        {categorizedPrompts.map((item, index: number) => (
-              <div
-              className="flex flex-col w-56 bg-gray-200/50 hover:bg-gray-200 rounded-lg cursor-pointer text-sm p-4 m-2"
-              key={index}
-              onClick={() => {
-                handleSubmit(item.prompt)
-              }}
-              >
-                <div className="flex-grow font-light line-camp-5">{item.prompt}</div>
-                <div className="mt-2 font-semibold justify-end">{item.category}</div>
-              </div>
-            ))
-        }
-      </div>
-    )
-  } else {
-    return <></>
-  }
+  return (
+    <div className="flex flex-wrap max-w-5xl">
+      {samples.map((item, index: number) => (
+        <div
+          className="flex flex-col w-56 bg-gray-200/50 hover:bg-gray-200 rounded-lg cursor-pointer text-sm p-4 m-2"
+          key={index}
+          onClick={() => {
+            handleSubmit(item.prompt)
+          }}
+        >
+          <div className="flex-grow font-light line-camp-5">{item.prompt}</div>
+          <div className="mt-2 font-semibold justify-end">{item.category}</div>
+        </div>
+      ))}
+    </div>
+  )
 }
 
 export default SamplePrompts

--- a/explore-assistant-extension/src/components/SamplePrompts.tsx
+++ b/explore-assistant-extension/src/components/SamplePrompts.tsx
@@ -30,7 +30,7 @@ const SamplePrompts = () => {
     <div className="flex flex-wrap max-w-5xl">
       {samples.map((item, index: number) => (
         <div
-          className="flex flex-col w-56 bg-gray-200/50 hover:bg-gray-200 rounded-lg cursor-pointer text-sm p-4 m-2"
+          className="flex flex-col w-56 min-h-44 bg-gray-200/50 hover:bg-gray-200 rounded-lg cursor-pointer text-sm p-4 m-2"
           key={index}
           onClick={() => {
             handleSubmit(item.prompt)

--- a/explore-assistant-extension/src/hooks/useBigQueryExamples.ts
+++ b/explore-assistant-extension/src/hooks/useBigQueryExamples.ts
@@ -109,9 +109,11 @@ export const useBigQueryExamples = () => {
       response.forEach((row: any) => {
         exploreSamples[row['explore_id']] = JSON.parse(row['samples'])
       })
-      const [modelName, exploreId] = (response[0]['explore_id'] as string).split(':')
+      const exploreKey: string = response[0]['explore_id']
+      const [modelName, exploreId] = exploreKey.split(':')
       dispatch(setExploreSamples(exploreSamples))
       dispatch(setCurrenExplore({
+        exploreKey,
         modelName,
         exploreId
       }))

--- a/explore-assistant-extension/src/hooks/useLookerFields.ts
+++ b/explore-assistant-extension/src/hooks/useLookerFields.ts
@@ -1,40 +1,59 @@
 import { useContext, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { setDimensions, setMeasures, setLookerFieldsLoaded } from '../slices/assistantSlice'
+import {
+  AssistantState,
+  SemanticModel,
+  setIsSemanticModelLoaded,
+  setSemanticModels,
+} from '../slices/assistantSlice'
 import { RootState } from '../store'
 import { ExtensionContext } from '@looker/extension-sdk-react'
-import process from 'process'
 import { useErrorBoundary } from 'react-error-boundary'
 
 export const useLookerFields = () => {
-  const { exploreName, modelName } = useSelector(
-    (state: RootState) => state.assistant,
-  )
-  const lookerModel = modelName || process.env.LOOKER_MODEL || ''
-  const lookerExplore = exploreName || process.env.LOOKER_EXPLORE || ''
+  const {
+    examples: { exploreSamples },
+  } = useSelector((state: RootState) => state.assistant as AssistantState)
+
+  const supportedExplores = Object.keys(exploreSamples)
+
   const dispatch = useDispatch()
-  const { showBoundary } = useErrorBoundary();
+  const { showBoundary } = useErrorBoundary()
 
   const { core40SDK } = useContext(ExtensionContext)
-  
-  // load lookml metadata and provide completion status
+
+  // Load LookML metadata and provide completion status
   useEffect(() => {
-    if(!lookerModel || lookerModel === '' || !lookerExplore || lookerModel === '') {
-      showBoundary({message: "Default Looker Model or Explore is blank or unspecified"})
+    if (supportedExplores.length === 0) {
+      return
     }
-    dispatch(setLookerFieldsLoaded(false))
-    core40SDK
-      .ok(
-        core40SDK.lookml_model_explore({
-          lookml_model_name: lookerModel,
-          explore_name: lookerExplore,
-          fields: 'fields',
-        }),
-      )
-      .then(({ fields }) => {
+
+    const fetchSemanticModel = async (
+      lookerModel: string,
+      lookerExplore: string,
+    ): Promise<SemanticModel | undefined> => {
+      if (!lookerModel || !lookerExplore) {
+        showBoundary({
+          message: 'Default Looker Model or Explore is blank or unspecified',
+        })
+        return
+      }
+
+      try {
+        const response = await core40SDK.ok(
+          core40SDK.lookml_model_explore({
+            lookml_model_name: lookerModel,
+            explore_name: lookerExplore,
+            fields: 'fields',
+          }),
+        )
+
+        const { fields } = response
+
         if (!fields || !fields.dimensions || !fields.measures) {
-          return
+          return undefined
         }
+
         const dimensions = fields.dimensions
           .filter(({ hidden }: any) => !hidden)
           .map(({ name, type, label, description, tags }: any) => ({
@@ -55,13 +74,45 @@ export const useLookerFields = () => {
             tags,
           }))
 
-        dispatch(setDimensions(dimensions))
-        dispatch(setMeasures(measures))
-        dispatch(setLookerFieldsLoaded(true))
-      })
-      .catch((error) => {
-        showBoundary(error)
-        dispatch(setLookerFieldsLoaded(true))
-      })
-  }, [dispatch,showBoundary, modelName, exploreName]) // Dependencies array to avoid unnecessary re-executions
+        return {
+          dimensions,
+          measures,
+        }
+      } catch (error) {
+        showBoundary({
+          message: `Failed to fetch semantic model for ${lookerModel}::${lookerExplore}`,
+        })
+        return undefined
+      }
+    }
+
+    const loadSemanticModels = async () => {
+      try {
+        const fetchPromises = supportedExplores.map((explore) => {
+          const [lookerModel, lookerExplore] = explore.split('::')
+          return fetchSemanticModel(lookerModel, lookerExplore).then(
+            (model) => ({ explore, model })
+          )
+        })
+
+        const results = await Promise.all(fetchPromises)
+        const semanticModels: { [explore: string]: SemanticModel } = {}
+
+        results.forEach(({ explore, model }) => {
+          if (model) {
+            semanticModels[explore] = model
+          }
+        })
+
+        dispatch(setSemanticModels(semanticModels))
+        dispatch(setIsSemanticModelLoaded(true))
+      } catch (error) {
+        showBoundary({
+          message: 'Failed to load semantic models',
+        })
+      }
+    }
+
+    loadSemanticModels()
+  }, [showBoundary, supportedExplores, core40SDK, dispatch])
 }

--- a/explore-assistant-extension/src/hooks/useLookerFields.ts
+++ b/explore-assistant-extension/src/hooks/useLookerFields.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from 'react'
+import { useContext, useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import {
   AssistantState,
@@ -13,6 +13,7 @@ import { useErrorBoundary } from 'react-error-boundary'
 export const useLookerFields = () => {
   const {
     examples: { exploreSamples },
+    isSemanticModelLoaded,
   } = useSelector((state: RootState) => state.assistant as AssistantState)
 
   const supportedExplores = Object.keys(exploreSamples)
@@ -22,11 +23,21 @@ export const useLookerFields = () => {
 
   const { core40SDK } = useContext(ExtensionContext)
 
+  // Create a ref to track if the hook has already been called
+  const hasFetched = useRef(false)
+
   // Load LookML metadata and provide completion status
   useEffect(() => {
-    if (supportedExplores.length === 0) {
+    // if the hook has already been called, return
+    if (hasFetched.current) return
+
+    // if there are no supported explores or the semantic model is already loaded, return
+    if (supportedExplores.length === 0 || isSemanticModelLoaded) {
       return
     }
+    
+    // mark
+    hasFetched.current = true
 
     const fetchSemanticModel = async (
       modelName: string,
@@ -118,5 +129,5 @@ export const useLookerFields = () => {
     }
 
     loadSemanticModels()
-  }, [showBoundary, supportedExplores, core40SDK, dispatch])
+  }, [supportedExplores])
 }

--- a/explore-assistant-extension/src/hooks/useSendVertexMessage.ts
+++ b/explore-assistant-extension/src/hooks/useSendVertexMessage.ts
@@ -148,7 +148,7 @@ const useSendVertexMessage = () => {
 
       Here are some example prompts the user has asked so far and how to summarize them:
 
-${exploreRefinementExamples
+${exploreRefinementExamples && exploreRefinementExamples
   .map((item) => {
     const inputText = '"' + item.input.join('", "') + '"'
     return `- The sequence of prompts from the user: ${inputText}. The summarized prompts: "${item.output}"`
@@ -329,7 +329,7 @@ ${exploreRefinementExamples
             Example
             ----------
 
-          ${exploreGenerationExamples
+          ${exploreGenerationExamples && exploreGenerationExamples
             .map((item) => `input: "${item.input}" ; output: ${item.output}`)
             .join('\n')}
 

--- a/explore-assistant-extension/src/hooks/useSendVertexMessage.ts
+++ b/explore-assistant-extension/src/hooks/useSendVertexMessage.ts
@@ -6,7 +6,7 @@ import CryptoJS from 'crypto-js'
 import { RootState } from '../store'
 import process from 'process'
 import { useErrorBoundary } from 'react-error-boundary'
-import { Settings } from 'http2'
+import { Settings } from '../slices/assistantSlice'
 
 interface ModelParameters {
   max_output_tokens?: number
@@ -75,10 +75,6 @@ const useSendVertexMessage = () => {
     useSelector((state: RootState) => state.assistant)
   
   const isDataLoaded = bigQueryExamplesLoaded && lookerFieldsLoaded
-
-  const settings = useSelector<RootState, Settings>(
-    (state) => state.assistant.settings,
-  )
 
   const settings = useSelector<RootState, Settings>(
     (state) => state.assistant.settings,

--- a/explore-assistant-extension/src/pages/AgentPage/MessageThread.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/MessageThread.tsx
@@ -5,13 +5,14 @@ import Message from '../../components/Chat/Message'
 import ExploreMessage from '../../components/Chat/ExploreMessage'
 import SummaryMessage from '../../components/Chat/SummaryMessage'
 import { CircularProgress } from '@material-ui/core'
+import { ChatMessage } from '../../slices/assistantSlice'
 
 const MessageThread = () => {
   const { currentExploreThread, isQuerying } = useSelector(
     (state: RootState) => state.assistant,
   )
 
-  const messages = currentExploreThread.messages
+  const messages = currentExploreThread.messages as ChatMessage[]
   return (
     <div className="">
       {messages.map((message, index) => {
@@ -24,7 +25,7 @@ const MessageThread = () => {
             />
           )
         } else if (message.type === 'summarize') {
-          return <SummaryMessage key={index} queryArgs={message.exploreUrl} />
+          return <SummaryMessage key={index} message={message} />
         } else {
           return (
             <Message

--- a/explore-assistant-extension/src/pages/AgentPage/MessageThread.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/MessageThread.tsx
@@ -24,6 +24,8 @@ const MessageThread = () => {
           return (
             <ExploreMessage
               key={message.uuid}
+              modelName={currentExploreThread.modelName}
+              exploreId={currentExploreThread.exploreId}
               queryArgs={message.exploreUrl}
               prompt={message.summarizedPrompt}
             />

--- a/explore-assistant-extension/src/pages/AgentPage/MessageThread.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/MessageThread.tsx
@@ -5,31 +5,35 @@ import Message from '../../components/Chat/Message'
 import ExploreMessage from '../../components/Chat/ExploreMessage'
 import SummaryMessage from '../../components/Chat/SummaryMessage'
 import { CircularProgress } from '@material-ui/core'
-import { ChatMessage } from '../../slices/assistantSlice'
+import { AssistantState, ChatMessage } from '../../slices/assistantSlice'
 
 const MessageThread = () => {
   const { currentExploreThread, isQuerying } = useSelector(
-    (state: RootState) => state.assistant,
+    (state: RootState) => state.assistant as AssistantState,
   )
+
+  if(currentExploreThread === null) {
+    return <></>
+  }
 
   const messages = currentExploreThread.messages as ChatMessage[]
   return (
     <div className="">
-      {messages.map((message, index) => {
+      {messages.map((message) => {
         if (message.type === 'explore') {
           return (
             <ExploreMessage
-              key={index}
+              key={message.uuid}
               queryArgs={message.exploreUrl}
               prompt={message.summarizedPrompt}
             />
           )
         } else if (message.type === 'summarize') {
-          return <SummaryMessage key={index} message={message} />
+          return <SummaryMessage key={message.uuid} message={message} />
         } else {
           return (
             <Message
-              key={index}
+              key={message.uuid}
               message={message.message}
               actor={message.actor}
               createdAt={message.createdAt}

--- a/explore-assistant-extension/src/pages/AgentPage/Settings.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/Settings.tsx
@@ -1,13 +1,12 @@
 import React from 'react'
-import {
-  Modal,
-  Box,
-  Typography,
-  Switch,
-} from '@mui/material'
+import { Modal, Box, Typography, Switch } from '@mui/material'
 import { useSelector, useDispatch } from 'react-redux'
 import { RootState } from '../../store'
-import { setSetting, AssistantState } from '../../slices/assistantSlice'
+import {
+  setSetting,
+  AssistantState,
+  resetExploreAssistant,
+} from '../../slices/assistantSlice'
 
 interface SettingsModalProps {
   open: boolean
@@ -27,6 +26,13 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
         value: !settings[id].value,
       }),
     )
+  }
+
+  const handleReset = () => {
+    dispatch(resetExploreAssistant())
+    setInterval(() => {
+      window.location.reload()
+    }, 100)
   }
 
   if (!settings) return null
@@ -67,6 +73,12 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
             </li>
           ))}
         </ul>
+        <div
+          onClick={handleReset}
+          className="flex justify-start text-xs text-blue-500 hover:text-blue-600 cursor-pointer hover:underline mt-4"
+        >
+          reset explore assistant
+        </div>
       </Box>
     </Modal>
   )

--- a/explore-assistant-extension/src/pages/AgentPage/Settings.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/Settings.tsx
@@ -4,17 +4,10 @@ import {
   Box,
   Typography,
   Switch,
-  List,
-  ListItem,
-  ListItemText,
-  ListItemSecondaryAction,
-  MenuItem,
-  Select,
-  SelectChangeEvent
 } from '@mui/material'
 import { useSelector, useDispatch } from 'react-redux'
 import { RootState } from '../../store'
-import { setSetting, setExploreName, setExploreId, setModelName, resetChat } from '../../slices/assistantSlice'
+import { setSetting, AssistantState } from '../../slices/assistantSlice'
 
 interface SettingsModalProps {
   open: boolean
@@ -23,17 +16,9 @@ interface SettingsModalProps {
 
 const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
   const dispatch = useDispatch()
-  const { settings, exploreId, explores } = useSelector(
-    (state: RootState) => state.assistant,
+  const { settings } = useSelector(
+    (state: RootState) => state.assistant as AssistantState,
   )
-
-  const setSelectedExplore = (e: SelectChangeEvent<any>) => {
-    const parsedExploreID = e.target.value.split(":")
-    dispatch(setExploreName(parsedExploreID[1]))
-    dispatch(setModelName(parsedExploreID[0]))
-    dispatch(setExploreId(e.target.value.replace(":","/")))
-    dispatch(resetChat())
-  }
 
   const handleToggle = (id: string) => {
     dispatch(
@@ -53,7 +38,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
       aria-labelledby="settings-modal-title"
       className="flex items-center justify-center"
     >
-      <Box className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
+      <Box className="bg-white rounded-lg p-6 max-w-xl w-full mx-4">
         <Typography
           id="settings-modal-title"
           variant="h6"
@@ -62,45 +47,26 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
         >
           Settings
         </Typography>
-        <List>
+        <ul>
           {Object.entries(settings).map(([id, setting]) => (
-            <ListItem key={id + setting.name} className="py-2">
-              <ListItemText
-                primary={setting.name}
-                secondary={setting.description}
-                className="pr-4"
-              />
-              <ListItemSecondaryAction>
+            <li key={id} className="flex flex-row py-4">
+              <div className="flex-grow pr-4">
+                <div className="text-sm font-semibold">{setting.name}</div>
+                <div className="text-xs text-gray-500">
+                  {setting.description}
+                </div>
+              </div>
+              <div className="">
                 <Switch
-                edge="end"
-                onChange={() => handleToggle(id)}
-                checked={setting.value}
-                inputProps={{ 'aria-labelledby': `switch-${id}` }}
+                  edge="end"
+                  onChange={() => handleToggle(id)}
+                  checked={setting.value}
+                  inputProps={{ 'aria-labelledby': `switch-${id}` }}
                 />
-              </ListItemSecondaryAction>
-            </ListItem>
+              </div>
+            </li>
           ))}
-          <ListItem key={'explore-select'} className="py-2">
-            <ListItemText
-                primary={"Select your Explore"}
-                secondary={"Load a conversation with a different Explore. These explores are configured in the Backend deployment of Explore Assistant and are loaded dynamically from a table."}
-                className="pr-4"
-              />
-              <ListItemSecondaryAction>
-                <Select
-                  labelId="demo-simple-select-label"
-                  id="demo-simple-select"
-                  value={exploreId.replace("/",":")}
-                  label="Explore Select"
-                  onChange={setSelectedExplore}
-                >
-                  {explores.length > 0 && explores.map((explore, index) => (
-                    <MenuItem key={index} value={explore.explore_id}>{explore.explore_id.split(":")[1]}</MenuItem>
-                  ))}
-                </Select>
-              </ListItemSecondaryAction>
-          </ListItem>
-        </List>
+        </ul>
       </Box>
     </Modal>
   )

--- a/explore-assistant-extension/src/pages/AgentPage/Sidebar.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/Sidebar.tsx
@@ -134,29 +134,29 @@ const Sidebar = ({ expanded, toggleDrawer }: SidebarProps) => {
               {history.length == 0 && (
                 <div className="text-gray-400">No recent chats</div>
               )}
-              {reverseHistory.map((item, index) => (
-                <Tooltip
-                  key={item.uuid}
-                  title={item.summarizedPrompt}
-                  placement="right"
-                  arrow
-                >
-                  <div
-                    key={index}
-                    className={`flex items-center cursor-pointer hover:underline`}
-                    onClick={() => handleHistoryClick(item)}
+              {reverseHistory.map((item) => (
+                <div key={'history-' + item.uuid}>
+                  <Tooltip
+                    title={item.summarizedPrompt}
+                    placement="right"
+                    arrow
                   >
-                    <div className="">
-                      <ChatBubbleOutline
-                        fontSize="small"
-                        className="mr-2 text-gray-600"
-                      />
+                    <div
+                      className={`flex items-center cursor-pointer hover:underline`}
+                      onClick={() => handleHistoryClick(item)}
+                    >
+                      <div className="">
+                        <ChatBubbleOutline
+                          fontSize="small"
+                          className="mr-2 text-gray-600"
+                        />
+                      </div>
+                      <div className="line-clamp-1">
+                        <span className="ml-3">{item.summarizedPrompt}</span>
+                      </div>
                     </div>
-                    <div className="line-clamp-1">
-                      <span className="ml-3">{item.summarizedPrompt}</span>
-                    </div>
-                  </div>
-                </Tooltip>
+                  </Tooltip>
+                </div>
               ))}
             </div>
           </div>

--- a/explore-assistant-extension/src/pages/AgentPage/Sidebar.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/Sidebar.tsx
@@ -159,10 +159,6 @@ const Sidebar = ({ expanded, toggleDrawer }: SidebarProps) => {
                 </Tooltip>
               ))}
             </div>
-
-            {reverseHistory.length === 0 && (
-              <div className="text-gray-400">No recent chats</div>
-            )}
           </div>
         )}
       </nav>

--- a/explore-assistant-extension/src/pages/AgentPage/Sidebar.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/Sidebar.tsx
@@ -7,9 +7,13 @@ import ChatBubbleOutline from '@mui/icons-material/ChatBubbleOutline'
 import { useDispatch, useSelector } from 'react-redux'
 import {
   clearHistory,
+  ExploreThread,
+  openSidePanel,
   resetChat,
+  setCurrentThread,
   setIsChatMode,
   setQuery,
+  setSidePanelExploreUrl,
 } from '../../slices/assistantSlice'
 import { RootState } from '../../store'
 import SettingsModal from './Settings'
@@ -56,17 +60,20 @@ const Sidebar = ({ expanded, toggleDrawer }: SidebarProps) => {
     }
   }
 
-  const handleHistoryClick = (message: string) => {
+  const handleHistoryClick = (thread: ExploreThread) => {
     dispatch(resetChat())
-    dispatch(setQuery(message))
+    dispatch(setCurrentThread(thread))
     dispatch(setIsChatMode(true))
+    dispatch(setSidePanelExploreUrl(thread.exploreUrl))
+    dispatch(openSidePanel())
+
   }
 
   const handleClearHistory = () => {
     dispatch(clearHistory())
   }
 
-  const reverseHistory = [...history].reverse()
+  const reverseHistory = [...history].reverse() as ExploreThread[]
 
   return (
     <div
@@ -138,11 +145,11 @@ const Sidebar = ({ expanded, toggleDrawer }: SidebarProps) => {
                 <div className="text-gray-400">No recent chats</div>
               )}
               {reverseHistory.map((item, index) => (
-                <Tooltip title={item.message} placement="right" arrow>
+                <Tooltip key={item.uuid} title={item.summarizedPrompt} placement="right" arrow>
                   <div
                     key={index}
                     className={`flex items-center cursor-pointer hover:underline`}
-                    onClick={() => handleHistoryClick(item.message)}
+                    onClick={() => handleHistoryClick(item)}
                   >
                     <div className="">
                       <ChatBubbleOutline
@@ -151,7 +158,7 @@ const Sidebar = ({ expanded, toggleDrawer }: SidebarProps) => {
                       />
                     </div>
                     <div className="line-clamp-1">
-                      <span className="ml-3">{item.message}</span>
+                      <span className="ml-3">{item.summarizedPrompt}</span>
                     </div>
                   </div>
                 </Tooltip>

--- a/explore-assistant-extension/src/pages/AgentPage/Sidebar.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/Sidebar.tsx
@@ -12,7 +12,6 @@ import {
   resetChat,
   setCurrentThread,
   setIsChatMode,
-  setQuery,
   setSidePanelExploreUrl,
 } from '../../slices/assistantSlice'
 import { RootState } from '../../store'

--- a/explore-assistant-extension/src/pages/AgentPage/Sidebar.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/Sidebar.tsx
@@ -13,10 +13,7 @@ import {
   setCurrentThread,
   setIsChatMode,
   setSidePanelExploreUrl,
-  setQuery,
-  setExploreId,
-  setExploreName,
-  setModelName,
+  AssistantState,
 } from '../../slices/assistantSlice'
 import { RootState } from '../../store'
 import SettingsModal from './Settings'
@@ -30,18 +27,9 @@ const Sidebar = ({ expanded, toggleDrawer }: SidebarProps) => {
   const dispatch = useDispatch()
   const [isExpanded, setIsExpanded] = React.useState(expanded)
   const [isSettingsOpen, setIsSettingsOpen] = React.useState(false)
-  const { isChatMode, isQuerying, history, bigQueryExamplesLoaded, lookerFieldsLoaded, sidebarMessage } = useSelector(
-    (state: RootState) => state.assistant,
+  const { isChatMode, isQuerying, history } = useSelector(
+    (state: RootState) => state.assistant as AssistantState,
   )
-
-  const sidebarItems = [
-    { text: 'New chat' },
-    { text: 'Ready to Assist' },
-    { text: 'Which Extensions?' },
-    { text: 'Embedding Videos' },
-    { text: 'Corrected Dagster' },
-    { text: 'Camel in the Desert' },
-  ]
 
   const handleClick = () => {
     if (expanded) {
@@ -69,23 +57,7 @@ const Sidebar = ({ expanded, toggleDrawer }: SidebarProps) => {
     dispatch(setIsChatMode(true))
     dispatch(setSidePanelExploreUrl(thread.exploreUrl))
     dispatch(openSidePanel())
-
-    const [modelName, exploreName] = message.exploreId.split("/");
-
-    dispatch(setExploreId(message.exploreId))
-    dispatch(setExploreName(exploreName))
-    dispatch(setModelName(modelName))
-
   }
-
-  React.useEffect(() => {
-    if(bigQueryExamplesLoaded && lookerFieldsLoaded && sidebarMessage !== '') {
-        dispatch(resetChat())
-        dispatch(setQuery(sidebarMessage))
-        dispatch(setIsChatMode(true))
-
-    }
-  },[dispatch, sidebarMessage, bigQueryExamplesLoaded, lookerFieldsLoaded])
 
   const handleClearHistory = () => {
     dispatch(clearHistory())
@@ -163,7 +135,12 @@ const Sidebar = ({ expanded, toggleDrawer }: SidebarProps) => {
                 <div className="text-gray-400">No recent chats</div>
               )}
               {reverseHistory.map((item, index) => (
-                <Tooltip key={item.uuid} title={item.summarizedPrompt} placement="right" arrow>
+                <Tooltip
+                  key={item.uuid}
+                  title={item.summarizedPrompt}
+                  placement="right"
+                  arrow
+                >
                   <div
                     key={index}
                     className={`flex items-center cursor-pointer hover:underline`}
@@ -183,7 +160,7 @@ const Sidebar = ({ expanded, toggleDrawer }: SidebarProps) => {
               ))}
             </div>
 
-            {sidebarItems.length === 0 && (
+            {reverseHistory.length === 0 && (
               <div className="text-gray-400">No recent chats</div>
             )}
           </div>
@@ -208,7 +185,10 @@ const Sidebar = ({ expanded, toggleDrawer }: SidebarProps) => {
           </div>
         </Tooltip>
       </div>
-      <SettingsModal open={isSettingsOpen} onClose={() => setIsSettingsOpen(false)} />
+      <SettingsModal
+        open={isSettingsOpen}
+        onClose={() => setIsSettingsOpen(false)}
+      />
     </div>
   )
 }

--- a/explore-assistant-extension/src/pages/AgentPage/index.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/index.tsx
@@ -31,7 +31,6 @@ import {
   Select,
   Tooltip,
 } from '@mui/material'
-import { Expand } from '@mui/icons-material'
 
 const toCamelCase = (input: string): string => {
   // Remove underscores, make following letter uppercase
@@ -177,7 +176,7 @@ const AgentPage = () => {
       submitMessage()
       endOfMessagesRef.current?.scrollIntoView({ behavior: 'smooth' })
     }
-  }, [query, isDataLoaded, submitMessage])
+  }, [query, isDataLoaded])
 
   const toggleDrawer = () => {
     setExpanded(!expanded)

--- a/explore-assistant-extension/src/pages/AgentPage/index.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/index.tsx
@@ -73,12 +73,34 @@ const AgentPage = () => {
   })
 
   const submitMessage = useCallback(async () => {
+    if(query === '') {
+      return
+    }
+
     dispatch(setIsQuerying(true))
 
+    // update the prompt list
     let promptList = [query]
     if (currentExploreThread && currentExploreThread.promptList) {
       promptList = [...currentExploreThread.promptList, query]
     }
+
+    dispatch(
+      updateCurrentThread({
+        promptList,
+      }),
+    )
+
+    // set the explore if it is not set
+    if(!currentExploreThread?.modelName || !currentExploreThread?.exploreId) {
+      dispatch(updateCurrentThread({
+        exploreId: currentExplore.exploreId,
+        modelName: currentExplore.modelName,
+      }))
+    }
+
+    console.log('Prompt List: ', promptList)
+    console.log(currentExploreThread)
 
     dispatch(
       addMessage({
@@ -101,7 +123,8 @@ const AgentPage = () => {
     }
 
     const { dimensions, measures } = semanticModels[currentExplore.exploreKey]
-    const exploreGenerationExamples = examples.exploreGenerationExamples[currentExplore.exploreKey]
+    const exploreGenerationExamples =
+      examples.exploreGenerationExamples[currentExplore.exploreKey]
 
     const newExploreUrl = await generateExploreUrl(
       promptSummary,
@@ -158,12 +181,7 @@ const AgentPage = () => {
 
     // update the history with the current contents of the thread
     dispatch(updateLastHistoryEntry())
-  }, [
-    query,
-    semanticModels,
-    examples,
-    currentExplore,
-  ])
+  }, [query, semanticModels, examples, currentExplore, currentExploreThread])
 
   const isDataLoaded = isBigQueryMetadataLoaded && isSemanticModelLoaded
 

--- a/explore-assistant-extension/src/pages/AgentPage/index.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/index.tsx
@@ -63,7 +63,8 @@ const AgentPage = () => {
     measures,
     examples,
     lookerFieldsLoaded,
-    bigQueryMetadataLoaded,
+    isBigQueryMetadataLoaded,
+    isSemanticModelLoaded,
   } = useSelector((state: RootState) => state.assistant as AssistantState)
 
   const explores = Object.keys(examples.exploreSamples).map((key) => {
@@ -167,7 +168,7 @@ const AgentPage = () => {
     currentExplore,
   ])
 
-  const isDataLoaded = bigQueryMetadataLoaded && lookerFieldsLoaded
+  const isDataLoaded = isBigQueryMetadataLoaded && lookerFieldsLoaded
 
   useEffect(() => {
     if (!query || query === '') {
@@ -184,12 +185,7 @@ const AgentPage = () => {
     setExpanded(!expanded)
   }
 
-  const isAgentReady =
-    dimensions.length > 0 &&
-    measures.length > 0 &&
-    examples.exploreGenerationExamples.length > 0 &&
-    examples.exploreRefinementExamples.length > 0 &&
-    bigQueryMetadataLoaded
+  const isAgentReady = isBigQueryMetadataLoaded && isSemanticModelLoaded
 
   if (!isAgentReady) {
     return (

--- a/explore-assistant-extension/src/pages/AgentPage/index.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/index.tsx
@@ -59,10 +59,8 @@ const AgentPage = () => {
     currentExploreThread,
     currentExplore,
     sidePanel,
-    dimensions,
-    measures,
     examples,
-    lookerFieldsLoaded,
+    semanticModels,
     isBigQueryMetadataLoaded,
     isSemanticModelLoaded,
   } = useSelector((state: RootState) => state.assistant as AssistantState)
@@ -103,11 +101,14 @@ const AgentPage = () => {
       return
     }
 
+    const { dimensions, measures } = semanticModels[currentExplore.exploreKey]
+    const exploreGenerationExamples = examples.exploreGenerationExamples[currentExplore.exploreKey]
+
     const newExploreUrl = await generateExploreUrl(
       promptSummary,
       dimensions,
       measures,
-      examples.exploreGenerationExamples,
+      exploreGenerationExamples,
     )
     console.log('New Explore URL: ', newExploreUrl)
     dispatch(setIsQuerying(false))
@@ -159,16 +160,13 @@ const AgentPage = () => {
     // update the history with the current contents of the thread
     dispatch(updateLastHistoryEntry())
   }, [
-    generateExploreUrl,
-    dispatch,
     query,
-    dimensions,
-    measures,
+    semanticModels,
     examples,
     currentExplore,
   ])
 
-  const isDataLoaded = isBigQueryMetadataLoaded && lookerFieldsLoaded
+  const isDataLoaded = isBigQueryMetadataLoaded && isSemanticModelLoaded
 
   useEffect(() => {
     if (!query || query === '') {

--- a/explore-assistant-extension/src/pages/AgentPage/index.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/index.tsx
@@ -22,15 +22,19 @@ import {
 } from '../../slices/assistantSlice'
 import MessageThread from './MessageThread'
 import clsx from 'clsx'
-import { Close } from '@material-ui/icons'
+import { Close, Home } from '@material-ui/icons'
 import {
+  Breadcrumbs,
   FormControl,
   InputLabel,
   LinearProgress,
   MenuItem,
   Select,
   Tooltip,
+  Typography,
 } from '@mui/material'
+import { current } from '@reduxjs/toolkit'
+import { getRelativeTimeString } from '../../utils/time'
 
 const toCamelCase = (input: string): string => {
   // Remove underscores, make following letter uppercase
@@ -73,7 +77,7 @@ const AgentPage = () => {
   })
 
   const submitMessage = useCallback(async () => {
-    if(query === '') {
+    if (query === '') {
       return
     }
 
@@ -92,11 +96,13 @@ const AgentPage = () => {
     )
 
     // set the explore if it is not set
-    if(!currentExploreThread?.modelName || !currentExploreThread?.exploreId) {
-      dispatch(updateCurrentThread({
-        exploreId: currentExplore.exploreId,
-        modelName: currentExplore.modelName,
-      }))
+    if (!currentExploreThread?.modelName || !currentExploreThread?.exploreId) {
+      dispatch(
+        updateCurrentThread({
+          exploreId: currentExplore.exploreId,
+          modelName: currentExplore.modelName,
+        }),
+      )
     }
 
     console.log('Prompt List: ', promptList)
@@ -232,8 +238,60 @@ const AgentPage = () => {
         } h-screen`}
       >
         <div className="flex-grow">
+          {isChatMode && (
+            <div className="z-10 flex flex-row items-start text-xs fixed inset w-full h-10 pl-2 bg-gray-50 border-b border-gray-200">
+              <ol
+                role="list"
+                className="flex w-full max-w-screen-xl space-x-4 px-4 sm:px-6 lg:px-4"
+              >
+                <li className="flex">
+                  <div className="flex items-center">Explore Assistant</div>
+                </li>
+
+                <li className="flex">
+                  <div className="flex items-center h-10 ">
+                    <svg
+                      fill="currentColor"
+                      viewBox="0 0 44 44"
+                      preserveAspectRatio="none"
+                      aria-hidden="true"
+                      className="h-full w-6 flex-shrink-0 text-gray-300"
+                    >
+                      <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
+                    </svg>
+                    <div className="ml-4 text-xs font-medium text-gray-500 hover:text-gray-700">
+                      {toCamelCase(currentExploreThread?.exploreId || '')}
+                    </div>
+                  </div>
+                </li>
+
+                <li className="flex">
+                  <div className="flex items-center h-10">
+                    <svg
+                      fill="currentColor"
+                      viewBox="0 0 44 44"
+                      preserveAspectRatio="none"
+                      aria-hidden="true"
+                      className="h-full w-6 flex-shrink-0 text-gray-300"
+                    >
+                      <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
+                    </svg>
+                    <div className="ml-4 text-xs font-medium text-gray-500 hover:text-gray-700">
+                      Chat (started{' '}
+                      {getRelativeTimeString(
+                        currentExploreThread?.createdAt
+                          ? new Date(currentExploreThread.createdAt)
+                          : new Date(),
+                      )}
+                      )
+                    </div>
+                  </div>
+                </li>
+              </ol>
+            </div>
+          )}
           {isChatMode ? (
-            <div className="relative flex flex-row h-screen px-4 pt-4 ">
+            <div className="relative flex flex-row h-screen px-4 pt-6 ">
               <div
                 className={clsx(
                   'flex flex-col relative',
@@ -257,7 +315,9 @@ const AgentPage = () => {
                         </div>
                       </div>
                     ) : (
-                      <MessageThread />
+                      <div className="pt-8">
+                        <MessageThread />
+                      </div>
                     )}
                   </div>
                 </div>
@@ -270,7 +330,7 @@ const AgentPage = () => {
 
               <div
                 className={clsx(
-                  'flex-grow flex flex-col pb-2 pl-2 transition-all duration-300 ease-in-out transform max-w-0',
+                  'flex-grow flex flex-col pb-2 pl-2 pt-8 transition-all duration-300 ease-in-out transform max-w-0',
                   sidePanel.isSidePanelOpen
                     ? 'max-w-full translate-x-0 opacity-100'
                     : 'translate-x-full opacity-0',

--- a/explore-assistant-extension/src/slices/assistantSlice.ts
+++ b/explore-assistant-extension/src/slices/assistantSlice.ts
@@ -170,6 +170,9 @@ export const assistantSlice = createSlice({
   name: 'assistant',
   initialState,
   reducers: {
+    resetExploreAssistant: () => {
+      return initialState
+    },
     setIsQuerying: (state, action: PayloadAction<boolean>) => {
       state.isQuerying = action.payload
     },
@@ -344,6 +347,8 @@ export const {
   updateSummaryMessage,
 
   setCurrenExplore,
+
+  resetExploreAssistant,
 } = assistantSlice.actions
 
 export default assistantSlice.reducer

--- a/explore-assistant-extension/src/slices/assistantSlice.ts
+++ b/explore-assistant-extension/src/slices/assistantSlice.ts
@@ -74,6 +74,7 @@ export type ExploreThread = {
   uuid: string
   exploreId: string
   modelName: string
+  exploreKey: string
   messages: ChatMessage[]
   exploreUrl: string
   summarizedPrompt: string
@@ -121,6 +122,7 @@ export interface AssistantState {
 export const newThreadState = () => {
   const thread: ExploreThread = {    
     uuid: uuidv4(),
+    exploreKey: '',
     exploreId: '',
     modelName: '',
     messages: [],

--- a/explore-assistant-extension/src/slices/assistantSlice.ts
+++ b/explore-assistant-extension/src/slices/assistantSlice.ts
@@ -39,7 +39,6 @@ interface Field {
 interface Sample {
   category: string
   prompt: string
-  color: string
 }
 
 export interface Message {

--- a/explore-assistant-extension/src/slices/assistantSlice.ts
+++ b/explore-assistant-extension/src/slices/assistantSlice.ts
@@ -79,6 +79,7 @@ export type ExploreThread = {
   exploreUrl: string
   summarizedPrompt: string
   promptList: string[]
+  createdAt: number
 }
 
 
@@ -127,6 +128,7 @@ export const newThreadState = () => {
     exploreUrl: '',
     summarizedPrompt: '',
     promptList: [],
+    createdAt: Date.now()
   }
   return thread
 }

--- a/explore-assistant-extension/src/slices/assistantSlice.ts
+++ b/explore-assistant-extension/src/slices/assistantSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, current, PayloadAction } from '@reduxjs/toolkit'
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { v4 as uuidv4 } from 'uuid'
 
 export interface Setting {

--- a/explore-assistant-extension/src/slices/assistantSlice.ts
+++ b/explore-assistant-extension/src/slices/assistantSlice.ts
@@ -12,18 +12,18 @@ export interface Settings {
 }
 
 export interface ExploreSamples {
-  [explore_id: string]: Sample[]
+  [exploreKey: string]: Sample[]
 }
 
 export interface ExploreExamples {
-  [explore_id: string]: {
+  [exploreKey: string]: {
     input: string
     output: string
   }[]
 }
 
 export interface RefinementExamples {
-  [explore_id: string]: {
+  [exploreKey: string]: {
     input: string[]
     output: string
   }[]
@@ -85,6 +85,9 @@ export type ExploreThread = {
 export interface SemanticModel {
   dimensions: Field[]
   measures: Field[]
+  exploreKey: string
+  exploreId: string
+  modelName: string
 }
 
 export interface AssistantState {
@@ -92,6 +95,7 @@ export interface AssistantState {
   isChatMode: boolean
   currentExploreThread: ExploreThread | null
   currentExplore: {
+    exploreKey: string
     modelName: string
     exploreId: string
   }
@@ -101,7 +105,7 @@ export interface AssistantState {
   }
   history: ExploreThread[]
   semanticModels: {
-    [explore: string]: SemanticModel
+    [exploreKey: string]: SemanticModel
   }
   query: string
   examples: {
@@ -110,7 +114,6 @@ export interface AssistantState {
     exploreSamples: ExploreSamples
   },
   settings: Settings,
-  lookerFieldsLoaded: boolean,
   isBigQueryMetadataLoaded: boolean,
   isSemanticModelLoaded: boolean
 }
@@ -133,6 +136,7 @@ export const initialState: AssistantState = {
   isChatMode: false,
   currentExploreThread: null,
   currentExplore: {
+    exploreKey: '',
     modelName: '',
     exploreId: ''
   },
@@ -155,7 +159,6 @@ export const initialState: AssistantState = {
       value: false,
     },
   },
-  lookerFieldsLoaded: false,
   isBigQueryMetadataLoaded: false,
   isSemanticModelLoaded: false
 }
@@ -290,12 +293,6 @@ export const assistantSlice = createSlice({
     ) {
       state.examples.exploreSamples = action.payload
     },
-    setLookerFieldsLoaded: (
-      state, 
-      action: PayloadAction<boolean>
-    ) => {
-      state.lookerFieldsLoaded = action.payload
-    },
     setisBigQueryMetadataLoaded: (
       state, 
       action: PayloadAction<boolean>
@@ -330,7 +327,6 @@ export const {
   setExploreSamples,
 
   setisBigQueryMetadataLoaded,
-  setLookerFieldsLoaded,
 
   updateCurrentThread,
   setCurrentThread,

--- a/explore-assistant-extension/src/store.ts
+++ b/explore-assistant-extension/src/store.ts
@@ -8,6 +8,7 @@ import assistantReducer, {
   Settings,
 } from './slices/assistantSlice'
 
+
 // Define keys that should never be persisted
 const neverPersistKeys: (keyof AssistantState)[] = [
   'dimensions',
@@ -57,9 +58,10 @@ const filterTransform = createTransform(
 )
 
 const persistConfig = {
-  key: 'root',
+  key: 'explore-assistant-state',
+  version: 1,
   storage,
-  whitelist: ['assistant'], // only assistant will be persisted
+  whitelist: ['assistant'],
   transforms: [filterTransform],
 }
 

--- a/explore-assistant-extension/src/store.ts
+++ b/explore-assistant-extension/src/store.ts
@@ -14,7 +14,7 @@ const neverPersistKeys: (keyof AssistantState)[] = [
   'dimensions',
   'measures',
   'examples',
-  'bigQueryMetadataLoaded',
+  'isBigQueryMetadataLoaded',
 ]
 
 // Create a transform function to filter out specific keys

--- a/explore-assistant-extension/src/store.ts
+++ b/explore-assistant-extension/src/store.ts
@@ -11,10 +11,10 @@ import assistantReducer, {
 
 // Define keys that should never be persisted
 const neverPersistKeys: (keyof AssistantState)[] = [
-  'dimensions',
-  'measures',
+  'semanticModels',
   'examples',
   'isBigQueryMetadataLoaded',
+  'isSemanticModelLoaded',
 ]
 
 // Create a transform function to filter out specific keys

--- a/explore-assistant-extension/src/store.ts
+++ b/explore-assistant-extension/src/store.ts
@@ -14,6 +14,7 @@ const neverPersistKeys: (keyof AssistantState)[] = [
   'dimensions',
   'measures',
   'examples',
+  'bigQueryMetadataLoaded',
 ]
 
 // Create a transform function to filter out specific keys

--- a/explore-assistant-extension/src/utils/time.ts
+++ b/explore-assistant-extension/src/utils/time.ts
@@ -1,0 +1,67 @@
+export const getHumanReadableDuration = (startDateTime: string, endDateTime: string): string => {
+    const start = new Date(startDateTime)
+    const end = new Date(endDateTime)
+  
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+      throw new Error('Invalid date-time string')
+    }
+  
+    const durationMilliseconds = end.getTime() - start.getTime()
+    let durationSeconds = Math.floor(durationMilliseconds / 1000)
+    const durationMinutes = Math.floor(durationSeconds / 60)
+    const durationHours = Math.floor(durationMinutes / 60)
+  
+    durationSeconds %= 60
+    const remainingMinutes = durationMinutes % 60
+  
+    const parts: string[] = []
+    if (durationHours > 0) {
+      parts.push(`${durationHours} ${durationHours === 1 ? 'hour' : 'hours'}`)
+    }
+    if (remainingMinutes > 0) {
+      parts.push(`${remainingMinutes} ${remainingMinutes === 1 ? 'minute' : 'minutes'}`)
+    }
+    if (durationSeconds > 0 || parts.length === 0) {
+      parts.push(`${durationSeconds} ${durationSeconds === 1 ? 'second' : 'seconds'}`)
+    }
+  
+    return parts.join(' ')
+  }
+  
+  export const getRelativeTimeString = (dateStr: string | Date) => {
+    const date = new Date(dateStr)
+    const now = new Date()
+  
+    const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000)
+    const diffInMinutes = Math.floor(diffInSeconds / 60)
+    const diffInHours = Math.floor(diffInMinutes / 60)
+    const diffInDays = Math.floor(diffInHours / 24)
+  
+    // Function to format the date as "Oct 25, 2023"
+    const formatDate = (date: Date) => {
+      const options: Intl.DateTimeFormatOptions = {
+        month: 'short', // allowed values: 'numeric', '2-digit', 'long', 'short', 'narrow'
+        day: 'numeric', // allowed values: 'numeric', '2-digit'
+        year: 'numeric', // allowed values: 'numeric', '2-digit'
+      }
+      return date.toLocaleDateString('en-US', options)
+    }
+  
+    let relativeTime
+  
+    if (diffInSeconds < 1) {
+      relativeTime = 'just now'
+    } else if (diffInSeconds < 60) {
+      relativeTime = diffInSeconds === 1 ? '1 second ago' : `${diffInSeconds} seconds ago`
+    } else if (diffInMinutes < 60) {
+      relativeTime = diffInMinutes === 1 ? '1 minute ago' : `${diffInMinutes} minutes ago`
+    } else if (diffInHours < 24) {
+      relativeTime = diffInHours === 1 ? '1 hour ago' : `${diffInHours} hours ago`
+    } else if (diffInDays <= 2) {
+      relativeTime = diffInDays === 1 ? '1 day ago' : `${diffInDays} days ago`
+    } else {
+      relativeTime = formatDate(date)
+    }
+  
+    return relativeTime
+  }


### PR DESCRIPTION
The history in the sidebar saves the entire contents of the thread, not just the summarized message. We also only re-run the summary once per message since we save the result in the state. We now use uuids for the threads and messages to be able to uniquely identify them.