### PR TITLE
Start with a new chat on page refresh

### DIFF
--- a/explore-assistant-extension/src/store.ts
+++ b/explore-assistant-extension/src/store.ts
@@ -15,6 +15,8 @@ const neverPersistKeys: (keyof AssistantState)[] = [
   'examples',
   'isBigQueryMetadataLoaded',
   'isSemanticModelLoaded',
+  'currentExploreThread',
+  'isChatMode',
 ]
 
 // Create a transform function to filter out specific keys


### PR DESCRIPTION
Don't save the current explore thread in the persisted state, and default to the default chat mode. This will have the effect of providing the new chat interface on page refresh, or on first arrival to the explore assistant.