### PR TITLE
Docs: Create single shared .env file

### DIFF
--- a/explore-assistant-examples/.env
+++ b/explore-assistant-examples/.env
@@ -1,5 +1,5 @@
 ##Update the variables in this environment file to automate the bash scripts for loading & updating the examples
 
-PROJECT_ID="PROJECT_ID"
-DATASET_ID="DATASET_ID"
-EXPLORE_ID="MODEL:EXPLORE_ID"
+PROJECT_ID="PROJECT_ID"                          ##Required. The Google Cloud project ID where your BigQuery dataset resides.
+DATASET_ID="DATASET_ID"                          ##The ID of the BigQuery dataset. Defaults to explore_assistant.
+EXPLORE_ID="MODEL:EXPLORE_ID"                    ##Required. A unique identifier for the dataset rows related to a specific use case or query (used in deletion and insertion).

--- a/explore-assistant-examples/.env
+++ b/explore-assistant-examples/.env
@@ -1,0 +1,5 @@
+##Update the variables in this environment file to automate the bash scripts for loading & updating the examples
+
+PROJECT_ID="PROJECT_ID"
+DATASET_ID="DATASET_ID"
+EXPLORE_ID="MODEL:EXPLORE_ID"


### PR DESCRIPTION
I added a single shared environment file that the developer can fill in the values for one time, streamlining the example generation and updating process.