### PR TITLE
Remove reference to unused environment variables.

### DIFF
--- a/explore-assistant-extension/src/components/Error/ErrorFallback.tsx
+++ b/explore-assistant-extension/src/components/Error/ErrorFallback.tsx
@@ -20,7 +20,6 @@ export default function Fallback({ error}: {error: any}) {
       lookmlNotFoundErr: {
         diagnosis: "The error is likely related to your Look specific `.env` variables.",
         steps: [
-          "Check the `LOOKML_MODEL` & `LOOKML_EXPLORE` env variables for your extension. Are they valid (spelling) & exist in your Looker instance?",
           "Make sure your user has access to this model and explore. At the very least with [`see_lookml`](https://cloud.google.com/looker/docs/admin-panel-users-roles#permissions_list) permissions.",
           "Check the Connection environment variables. Do valid BQ connections by those names exist in your Looker instance?"
         ]


### PR DESCRIPTION
PR 72 removes these environment vars, but missed this reference. 

https://github.com/looker-open-source/looker-explore-assistant/pull/72