### PR TITLE
Fix(BigQuery terraform): Fixed issue with BQ terraform to create BQ model

### DIFF
--- a/explore-assistant-backend/terraform/bigquery/main.tf
+++ b/explore-assistant-backend/terraform/bigquery/main.tf
@@ -24,6 +24,11 @@ resource "google_project_iam_member" "bigquery_connection_remote_model" {
   member     = format("serviceAccount:%s", google_bigquery_connection.connection.cloud_resource[0].service_account_id)
 }
 
+resource "time_sleep" "wait_after_iam_assignment" {
+  depends_on      = [ google_project_iam_member.bigquery_connection_remote_model ]
+  create_duration = "120s"
+}
+
 resource "google_bigquery_job" "create_bq_model_llm" {
   job_id = "create_looker_llm_model-${formatdate("YYYYMMDDhhmmss", timestamp())}"
   query {
@@ -42,7 +47,7 @@ EOF
   }
 
   location = var.deployment_region
-
+  depends_on = [ google_project_iam_member.bigquery_connection_remote_model, time_sleep.wait_after_iam_assignment ]
   lifecycle {
     ignore_changes  = [query, job_id]
   }


### PR DESCRIPTION
BigQuery terraform script was running successfully but a remote model was not being created in the BQ dataset. The create_looker_llm_model job was failing with following error
<img width="538" alt="Screenshot 2024-11-12 at 3 57 52 PM" src="https://github.com/user-attachments/assets/4754fbcc-3b13-47f9-beaa-b194cc44100c">

Cause: The IAM permissions on the service account were not propagated at the time create_looker_llm_model job was triggered
Fix: Added time sleep (120s) to give enough time for IAM changes to take effect
Testing: Ran BQ terraform and create_looker_llm_model completed successfully. The BQ model was created in the expected dataset