### PR TITLE
Update README.md

### DIFF
--- a/explore-assistant-extension/README.md
+++ b/explore-assistant-extension/README.md
@@ -64,7 +64,6 @@ jsonPayload.component="explore-assistant-metadata"
    ```
    VERTEX_BIGQUERY_LOOKER_CONNECTION_NAME=<This is the connection name in Looker with the BQ project that has access to the remote connection and model>
    BIGQUERY_EXAMPLE_PROMPTS_CONNECTION_NAME=<The BQ connection name in Looker that has query access to example prompts. This may be the same as the Vertex Connection Name if using just one gcp project>
-   BIGQUERY_EXAMPLE_PROMPTS_DATASET_NAME=<This is the dataset and project that contain the Example prompt data, assuming that differs from the Looker connection>
    ```
 
    Optionally, include and specify the below variable if your BQ project housing the example prompts for Explore Assistant (see [Examples folder](../explore-assistant-examples/README.md)) is different than the project set by default in your BQ connection to Looker. If unspecified, it defaults to the current BigQuery project in your Looker connection & `explore_assistant` as the dataset name.


### PR DESCRIPTION
Remove BIGQUERY_EXAMPLE_PROMPTS_DATASET_NAME from mandatory fields. It seems it shouldn't be mandatory based on instructions in next section.